### PR TITLE
Feat: modo oscuro global via Spark filter sin tocar templates

### DIFF
--- a/src/main/java/com/is1/proyecto/App.java
+++ b/src/main/java/com/is1/proyecto/App.java
@@ -1,5 +1,6 @@
 package com.is1.proyecto; // Define el paquete de la aplicación, debe coincidir con la estructura de carpetas.
 
+import com.is1.proyecto.config.DarkModeFilter; // Filtro de modo oscuro global.
 import com.is1.proyecto.config.DBConfigSingleton; // Clase Singleton para la configuración de la base de datos.
 import com.is1.proyecto.config.DBConnectionFilter; // Filtros de conexión a la base de datos.
 import com.is1.proyecto.repositories.*;
@@ -24,6 +25,7 @@ import com.is1.proyecto.services.TeacherService;
 import com.is1.proyecto.services.UserService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import spark.Spark;
 import static spark.Spark.port;
 
 /**
@@ -42,6 +44,9 @@ public class App {
     public static void main(String[] args) {
         int serverPort = Integer.parseInt(System.getProperty("server.port", "8080"));
         port(serverPort);
+
+        // --- Configuración de archivos estáticos ---
+        Spark.staticFiles.location("/public");
 
         // --- Configuración de la base de datos ---
         DBConfigSingleton dbConfig = DBConfigSingleton.getInstance();
@@ -101,5 +106,10 @@ public class App {
         new StudyPlanRoutes(studyPlanService, careerService, subjectService).register();
         new SubjectRoutes(subjectService, conditionService, careerService, studyPlanService).register();
         new UserApiRoutes(authService, userService, objectMapper).register();
+
+        // --- Filtro de modo oscuro ---
+        // Debe registrarse al final, después de todas las rutas y filtros,
+        // para garantizar que el body HTML ya esté completamente renderizado.
+        DarkModeFilter.register();
     }
 }

--- a/src/main/java/com/is1/proyecto/config/DarkModeFilter.java
+++ b/src/main/java/com/is1/proyecto/config/DarkModeFilter.java
@@ -1,0 +1,110 @@
+package com.is1.proyecto.config;
+
+import spark.Filter;
+import spark.Request;
+import spark.Response;
+import spark.Spark;
+
+import java.io.IOException;
+
+/**
+ * Filtro 'afterAfter' que inyecta recursos de modo oscuro en respuestas HTML.
+ * <p>
+ * Se ejecuta después de todos los filtros 'after' y del renderizado de templates,
+ * cuando {@code res.body()} contiene el HTML completo renderizado.
+ * <p>
+ * Responsabilidades:
+ * <ol>
+ *   <li>Inyectar el link al CSS de modo oscuro ({@code /css/dark-mode.css}) antes de {@code </head>}</li>
+ *   <li>Inyectar el script JS ({@code /js/dark-mode.js}) antes de {@code </head>}</li>
+ *   <li>Inyectar el botón flotante de alternancia antes de {@code </body>}</li>
+ * </ol>
+ * <p>
+ * Solo procesa respuestas HTML (según el header {@code Accept} del request).
+ * Las rutas JSON (API REST) no se ven afectadas.
+ * <p>
+ * Importante: usa {@code req.headers("Accept")} en vez de {@code res.type()}
+ * porque Spark setea el content-type en {@code Body.serializeTo()}, que corre
+ * <b>después</b> de los filtros {@code afterAfter}.
+ */
+public class DarkModeFilter {
+
+    private static final String CSS_LINK = "<link rel=\"stylesheet\" href=\"/css/dark-mode.css\">";
+    private static final String JS_SCRIPT = "<script src=\"/js/dark-mode.js\"></script>";
+
+    private static final String TOGGLE_BUTTON = ""
+            + "<button id=\"darkModeToggle\""
+            + " aria-label=\"Cambiar modo oscuro\""
+            + " style=\"position:fixed;top:1rem;left:1rem;z-index:9999;"
+            + "width:2.5rem;height:2.5rem;border-radius:9999px;background:#1f2937;"
+            + "color:#f9fafb;border:2px solid #374151;cursor:pointer;font-size:1.25rem;"
+            + "display:flex;align-items:center;justify-content:center;"
+            + "box-shadow:0 4px 12px rgba(0,0,0,0.25);transition:all 0.3s ease;"
+            + "\">\uD83C\uDF19</button>";
+
+    /**
+     * Crea el filtro 'afterAfter' que procesa respuestas HTML.
+     * <p>
+     * Verifica que el request acepte {@code text/html}, lee el cuerpo renderizado,
+     * inyecta los assets antes de {@code </head>} y el botón antes de {@code </body>},
+     * y reemplaza el body con la versión modificada.
+     * <p>
+     * Nota: NO usa {@code res.type()} porque Spark setea el content-type después
+     * de los filtros, en {@code Body.serializeTo()}.
+     *
+     * @return el filtro listo para ser registrado
+     */
+    private static Filter createFilter() {
+        return (Request req, Response res) -> {
+            try {
+                // Solo procesar respuestas HTML
+                String accept = req.headers("Accept");
+                if (accept == null || !accept.contains("text/html")) {
+                    return;
+                }
+
+                String body = res.body();
+                if (body == null || body.isEmpty()) {
+                    return;
+                }
+
+                // Inyectar CSS y JS antes de </head>
+                String headTag = "</head>";
+                int headIndex = body.indexOf(headTag);
+                if (headIndex == -1) {
+                    return; // Safety check: no </head> tag found
+                }
+
+                StringBuilder modified = new StringBuilder(body);
+                String headInjection = "\n    " + CSS_LINK + "\n    " + JS_SCRIPT + "\n  ";
+                modified.insert(headIndex, headInjection);
+
+                // Inyectar botón flotante antes de </body>
+                String bodyTag = "</body>";
+                int bodyIndex = modified.indexOf(bodyTag);
+                if (bodyIndex == -1) {
+                    return; // Safety check: no </body> tag found
+                }
+
+                String bodyInjection = "\n  " + TOGGLE_BUTTON + "\n";
+                modified.insert(bodyIndex, bodyInjection);
+
+                res.body(modified.toString());
+
+            } catch (Exception e) {
+                System.err.println("Error en DarkModeFilter: " + e.getMessage());
+            }
+        };
+    }
+
+    /**
+     * Registra el filtro 'afterAfter' en el pipeline de Spark.
+     * <p>
+     * Debe llamarse después de registrar todas las rutas y filtros 'before'/'after',
+     * para garantizar que el body HTML ya esté completamente renderizado.
+     */
+    public static void register() {
+        Spark.afterAfter(createFilter());
+        System.out.println("DarkModeFilter registrado correctamente");
+    }
+}

--- a/src/main/resources/public/css/dark-mode.css
+++ b/src/main/resources/public/css/dark-mode.css
@@ -1,0 +1,180 @@
+/* Dark Mode Overrides — IS2 */
+/* Applies when <html class="dark"> */
+
+/* ========== Backgrounds ========== */
+html.dark .bg-white { background-color: #1f2937; }
+html.dark .bg-gray-50 { background-color: #111827; }
+html.dark .bg-gray-100 { background-color: #111827; }
+html.dark .bg-gray-200 { background-color: #374151; }
+
+html.dark .bg-blue-50 { background-color: rgba(30, 58, 138, 0.3); }
+html.dark .bg-blue-100 { background-color: rgba(30, 58, 138, 0.4); }
+html.dark .bg-blue-500 { background-color: #2563eb; }
+html.dark .bg-blue-600 { background-color: #3b82f6; }
+
+html.dark .bg-indigo-50 { background-color: rgba(55, 48, 163, 0.3); }
+html.dark .bg-indigo-600 { background-color: #6366f1; }
+
+html.dark .bg-green-50 { background-color: rgba(6, 78, 59, 0.3); }
+html.dark .bg-green-100 { background-color: rgba(6, 78, 59, 0.4); }
+html.dark .bg-green-600 { background-color: #22c55e; }
+
+html.dark .bg-red-50 { background-color: rgba(127, 29, 29, 0.3); }
+html.dark .bg-red-100 { background-color: rgba(127, 29, 29, 0.4); }
+html.dark .bg-red-500 { background-color: #ef4444; }
+html.dark .bg-red-600 { background-color: #f87171; }
+
+html.dark .bg-teal-50 { background-color: rgba(19, 78, 74, 0.3); }
+html.dark .bg-teal-600 { background-color: #14b8a6; }
+
+html.dark .bg-cyan-50 { background-color: rgba(21, 94, 117, 0.3); }
+html.dark .bg-cyan-600 { background-color: #06b6d4; }
+
+html.dark .bg-amber-50 { background-color: rgba(120, 53, 15, 0.3); }
+html.dark .bg-amber-600 { background-color: #d97706; }
+
+html.dark .bg-purple-50 { background-color: rgba(88, 28, 135, 0.3); }
+html.dark .bg-purple-600 { background-color: #a855f7; }
+
+/* ========== Text Colors ========== */
+html.dark .text-gray-300 { color: #d1d5db; }
+html.dark .text-gray-400 { color: #9ca3af; }
+html.dark .text-gray-500 { color: #9ca3af; }
+html.dark .text-gray-600 { color: #d1d5db; }
+html.dark .text-gray-700 { color: #e5e7eb; }
+html.dark .text-gray-800 { color: #f3f4f6; }
+html.dark .text-gray-900 { color: #f9fafb; }
+
+html.dark .text-blue-600 { color: #60a5fa; }
+html.dark .text-blue-700 { color: #93c5fd; }
+
+html.dark .text-indigo-600 { color: #818cf8; }
+html.dark .text-indigo-700 { color: #a5b4fc; }
+
+html.dark .text-green-700 { color: #4ade80; }
+
+html.dark .text-red-600 { color: #f87171; }
+html.dark .text-red-700 { color: #fca5a5; }
+
+html.dark .text-teal-700 { color: #2dd4bf; }
+html.dark .text-cyan-700 { color: #22d3ee; }
+html.dark .text-purple-600 { color: #a855f7; }
+html.dark .text-purple-700 { color: #c084fc; }
+
+html.dark .text-amber-700 { color: #fbbf24; }
+
+html.dark .text-green-600 { color: #22c55e; }
+
+html.dark .text-yellow-600 { color: #eab308; }
+html.dark .text-yellow-800 { color: #fef08a; }
+
+/* ========== Border Colors ========== */
+html.dark .border-gray-200 { border-color: #374151; }
+html.dark .border-gray-300 { border-color: #4b5563; }
+
+html.dark .border-blue-200 { border-color: rgba(96, 165, 250, 0.3); }
+html.dark .border-blue-400 { border-color: rgba(96, 165, 250, 0.5); }
+html.dark .border-blue-500 { border-color: #3b82f6; }
+
+html.dark .border-indigo-200 { border-color: rgba(129, 140, 248, 0.3); }
+
+html.dark .border-green-200 { border-color: rgba(74, 222, 128, 0.3); }
+html.dark .border-green-400 { border-color: rgba(74, 222, 128, 0.5); }
+
+html.dark .border-red-200 { border-color: rgba(248, 113, 113, 0.3); }
+html.dark .border-red-400 { border-color: rgba(248, 113, 113, 0.5); }
+
+html.dark .border-teal-200 { border-color: rgba(45, 212, 191, 0.3); }
+html.dark .border-cyan-200 { border-color: rgba(34, 211, 238, 0.3); }
+html.dark .border-amber-200 { border-color: rgba(251, 191, 36, 0.3); }
+
+html.dark .border-purple-200 { border-color: rgba(192, 132, 252, 0.3); }
+
+/* ========== Hover States ========== */
+html.dark .hover\:bg-gray-50:hover { background-color: #374151; }
+html.dark .hover\:bg-blue-700:hover { background-color: #1d4ed8; }
+html.dark .hover\:bg-indigo-700:hover { background-color: #4338ca; }
+html.dark .hover\:bg-green-700:hover { background-color: #15803d; }
+html.dark .hover\:bg-red-700:hover { background-color: #b91c1c; }
+html.dark .hover\:bg-red-600:hover { background-color: #dc2626; }
+html.dark .hover\:bg-teal-700:hover { background-color: #0f766e; }
+html.dark .hover\:bg-cyan-700:hover { background-color: #0e7490; }
+html.dark .hover\:bg-amber-700:hover { background-color: #92400e; }
+
+html.dark .hover\:bg-purple-700:hover { background-color: #7e22ce; }
+
+html.dark .hover\:text-blue-800:hover { color: #93c5fd; }
+html.dark .hover\:text-gray-800:hover { color: #f3f4f6; }
+html.dark .hover\:text-indigo-800:hover { color: #c7d2fe; }
+html.dark .hover\:text-red-800:hover { color: #fca5a5; }
+html.dark .hover\:text-green-800:hover { color: #86efac; }
+html.dark .hover\:text-purple-800:hover { color: #d8b4fe; }
+html.dark .hover\:text-yellow-800:hover { color: #fef08a; }
+
+/* ========== Focus Rings ========== */
+html.dark .focus\:ring-blue-500:focus { --tw-ring-color: #3b82f6; }
+html.dark .focus\:ring-indigo-500:focus { --tw-ring-color: #6366f1; }
+html.dark .focus\:ring-purple-500:focus { --tw-ring-color: #a855f7; }
+
+/* ========== Table row hover ========== */
+html.dark .hover\:bg-gray-50:hover { background-color: #374151; }
+
+/* ========== Cards/containers inside colored sections ========== */
+html.dark .bg-blue-50 .bg-white,
+html.dark .bg-indigo-50 .bg-white,
+html.dark .bg-green-50 .bg-white,
+html.dark .bg-red-50 .bg-white,
+html.dark .bg-teal-50 .bg-white,
+html.dark .bg-cyan-50 .bg-white,
+html.dark .bg-purple-50 .bg-white {
+  background-color: #1f2937;
+}
+
+/* ========== Shadow adjustments ========== */
+html.dark .shadow-lg { box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.4), 0 4px 6px -2px rgba(0, 0, 0, 0.3); }
+html.dark .shadow-sm { box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.3); }
+html.dark .shadow { box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.3), 0 1px 2px 0 rgba(0, 0, 0, 0.2); }
+
+/* ========== Transitions for smooth theme switching ========== */
+html.dark,
+html.dark * {
+  transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+/* ========== Toggle button hover effect ========== */
+#darkModeToggle:hover {
+  transform: scale(1.1);
+  opacity: 0.9;
+}
+
+/* ========== Table header in dark mode ========== */
+html.dark .bg-gray-200 { background-color: #374151; }
+html.dark .uppercase.text-gray-700.text-sm { color: #d1d5db; }
+
+/* ========== Focus ring offset ========== */
+html.dark .focus\:ring-offset-2:focus { --tw-ring-offset-color: #1f2937; }
+
+/* ========== Focus border (input fields) ========== */
+html.dark .focus\:border-blue-500:focus { border-color: #3b82f6; }
+
+/* ========== Role badges (assignments) ========== */
+html.dark .bg-yellow-100 { background-color: rgba(113, 63, 18, 0.3); }
+html.dark .text-yellow-800 { color: #fbbf24; }
+
+/* ========== Table dividers ========== */
+html.dark .divide-gray-100 > :not([hidden]) ~ :not([hidden]) { border-color: #374151; }
+
+/* ========== Admin dashboard: cards con mismo color en dark mode ========== */
+/* Las 3 primeras cards del panel admin usan bg-indigo-50 → las diferenciamos por nth-child */
+html.dark .grid.grid-cols-1.gap-6.mb-8 > .bg-indigo-50:nth-child(1) {
+  background-color: rgba(55, 48, 163, 0.45);
+  border-color: rgba(99, 102, 241, 0.45);
+}
+html.dark .grid.grid-cols-1.gap-6.mb-8 > .bg-indigo-50:nth-child(2) {
+  background-color: rgba(76, 29, 149, 0.4);
+  border-color: rgba(168, 85, 247, 0.4);
+}
+html.dark .grid.grid-cols-1.gap-6.mb-8 > .bg-indigo-50:nth-child(3) {
+  background-color: rgba(30, 58, 138, 0.4);
+  border-color: rgba(59, 130, 246, 0.4);
+}

--- a/src/main/resources/public/js/dark-mode.js
+++ b/src/main/resources/public/js/dark-mode.js
@@ -1,0 +1,67 @@
+// dark-mode.js — Gestor de modo oscuro global
+(function() {
+  'use strict';
+  
+  const STORAGE_KEY = 'theme';
+  const DARK_CLASS = 'dark';
+
+  // Helper para localStorage con fallback
+  function getSavedTheme() {
+    try { return localStorage.getItem(STORAGE_KEY); } catch(e) { return null; }
+  }
+  function setSavedTheme(val) {
+    try { localStorage.setItem(STORAGE_KEY, val); } catch(e) { /* noop */ }
+  }
+  
+  // 1. Get saved preference or system preference
+  let theme = getSavedTheme();
+  if (!theme) {
+    theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
+  
+  // 2. Apply immediately (FOLM prevention)
+  if (theme === 'dark') {
+    document.documentElement.classList.add(DARK_CLASS);
+  }
+  
+  // 3. When DOM is ready, create the toggle button
+  function init() {
+    const btn = document.getElementById('darkModeToggle');
+    if (!btn) return;
+    
+    function updateIcon() {
+      const isDark = document.documentElement.classList.contains(DARK_CLASS);
+      btn.textContent = isDark ? '\u2600\uFE0F' : '\uD83C\uDF19';
+      btn.style.background = isDark ? '#f9fafb' : '#1f2937';
+      btn.style.color = isDark ? '#1f2937' : '#f9fafb';
+      btn.style.borderColor = isDark ? '#d1d5db' : '#374151';
+    }
+    
+    btn.addEventListener('click', function() {
+      document.documentElement.classList.toggle(DARK_CLASS);
+      const isDark = document.documentElement.classList.contains(DARK_CLASS);
+      setSavedTheme(isDark ? 'dark' : 'light');
+      updateIcon();
+    });
+    
+    updateIcon();
+  }
+  
+  // Run on DOMContentLoaded or immediately if already loaded
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+  
+  // Listen for system preference changes
+  window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function(e) {
+    if (!getSavedTheme()) {
+      if (e.matches) {
+        document.documentElement.classList.add(DARK_CLASS);
+      } else {
+        document.documentElement.classList.remove(DARK_CLASS);
+      }
+    }
+  });
+})();


### PR DESCRIPTION
Implementación de dark mode toggle para toda la app web usando un filter afterAfter de Spark que inyecta CSS overrides y un script JS de control en todas las respuestas HTML.

- DarkModeFilter.java: filter afterAfter que inyecta assets antes de </head> y botón toggle antes de </body>
- dark-mode.js: script síncrono con localStorage, prefers-color-scheme y FOLM prevention
- dark-mode.css: overrides html.dark para ~80 clases Tailwind distintas
- App.java: static file serving + registro del filter